### PR TITLE
Allow custom out directory and custom ExecStartPost entries via role variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,6 @@ certbot_gandi_domains: []
 
 # Destination directory for cert-assembler
 certbot_out_dir: /etc/k8router/certs
+
+certbot_execstartpost_tasks:
+  - /etc/certbot/cert-assembler.sh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,4 +20,4 @@ certbot_gandi_domains: []
 #     - "*.domain.example"
 
 # Destination directory for cert-assembler
-certbot_out_dir: changeme
+certbot_out_dir: /etc/k8router/certs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,5 @@ certbot_gandi_domains: []
 #   domains:
 #     - "*.domain.example"
 
+# Destination directory for cert-assembler
+certbot_out_dir: changeme

--- a/templates/cert-assembler.sh.j2
+++ b/templates/cert-assembler.sh.j2
@@ -37,7 +37,7 @@ for DOMAIN in "${DOMAINS[@]}" ; do
     CERT="$LE_BASE/$DOMAIN/cert.pem"
     KEY="$LE_BASE/$DOMAIN/privkey.pem"
     CHAIN="$LE_BASE/$DOMAIN/chain.pem"
-    OUT="/etc/k8router/certs/$DOMAIN"
+    OUT="{{ certbot_out_dir }}/$DOMAIN"
 
     mkdir -p "$OUT"
     rm -rf "$OUT/ocsp.ocsp"

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -5,7 +5,9 @@ Description=Renew LE certificates
 
 [Service]
 ExecStart=/usr/bin/certbot renew
-ExecStartPost=/etc/certbot/cert-assembler.sh
+{% for execstartpost_task in certbot_execstartpost_tasks %}
+ExecStartPost={{ execstartpost_task }}
+{% endfor %}
 Type=oneshot
 
 [Install]


### PR DESCRIPTION
Required to have the certs assembled to a different location e.g. `/etc/haproxy`. 